### PR TITLE
fix(deps): remove broken harden-configs lefthook extends

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,10 +1,6 @@
-extends:
-  - node_modules/harden-configs/lefthook/harden.yml
-
 pre-commit:
   parallel: true
   commands:
-    # Override harden template commands to use pnpm/vitest instead of bun
     lint:
       run: pnpm exec eslint {staged_files}
       glob: "*.{js,mjs,cjs,ts,tsx}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortcuts-mcp",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",

--- a/tsconfig.hardening.json
+++ b/tsconfig.hardening.json
@@ -1,7 +1,5 @@
 {
-  // Base hardening tsconfig — extend this from your project's tsconfig.json:
-  //   { "extends": "harden-configs/tsconfig" }
-  //
+  // Vendored hardening tsconfig — extend via "./tsconfig.hardening.json".
   // All flags below tighten type-safety. None affect emit; pair with your own
   // "compilerOptions.outDir", "include", and "module" settings.
   "compilerOptions": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,8 @@
 {
-  // Extends harden-configs/tsconfig for the shared hardening flags
-  // (strict, noUncheckedIndexedAccess, exactOptionalPropertyTypes,
-  //  noImplicitOverride, noFallthroughCasesInSwitch,
-  //  noPropertyAccessFromIndexSignature, forceConsistentCasingInFileNames).
-  //
-  // harden-configs is installed as a local file dep:
-  //   pnpm add -D /path/to/harden-configs
-  // The file: link is in package.json devDependencies.
+  // Extends ./tsconfig.hardening.json (vendored copy) for shared hardening flags:
+  // strict, noUncheckedIndexedAccess, exactOptionalPropertyTypes,
+  // noImplicitOverride, noFallthroughCasesInSwitch,
+  // noPropertyAccessFromIndexSignature, forceConsistentCasingInFileNames.
   //
   // noPropertyAccessFromIndexSignature is overridden to false here because
   // process.env.X access is pervasive and this flag is style-level, not


### PR DESCRIPTION
## Summary

- The `link:/Users/foxtrottwist/Repos/harden-configs` devDependency was removed in the previous vendor commit (`8ec32c6`) but `lefthook.yml` still extended `node_modules/harden-configs/lefthook/harden.yml`, which no longer exists in node_modules — making pre-commit hooks fail on any fresh clone
- Remove the `extends` stanza; all five commands (`lint`, `typecheck`, `test`, `secretlint`, `prettier`) were already defined locally and the extend added nothing
- Update stale comments in `tsconfig.json` and `tsconfig.hardening.json` to reflect the vendored approach instead of the old link: instructions
- Bump to 3.3.1

## Strategy

**Vendor** — both `tsconfig.hardening.json` and `eslint-hardening/index.mjs` are already copied in-repo. The lefthook extends was the last dangling reference; removing it completes the vendor approach. No external dep on harden-configs remains.

## Files changed

- `lefthook.yml` — remove broken `extends` block
- `tsconfig.json` — update comment to reflect vendored approach
- `tsconfig.hardening.json` — update comment header
- `package.json` — bump to 3.3.1

## Test plan

- [x] `pnpm install` — lockfile up to date, no resolution errors
- [x] `pnpm lint` — passes (0 errors, 16 pre-existing warnings)
- [x] Pre-commit hook ran cleanly on commit (prettier, secretlint, test, typecheck all passed)