### PR TITLE
fix(release): drop stale marketplace.json refs from prepareCmd

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "shortcuts-mcp",
+  "version": "3.3.1",
   "description": "MCP server that lets Claude run, view, and annotate macOS Shortcuts via a hybrid AppleScript + CLI approach. Covers interactive shortcuts (file pickers, dialogs), permission handling, and per-shortcut purpose tracking.",
   "author": {
     "name": "Law Horne",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "node -e \"const fs=require('fs'); const pkg=require('./package.json'); const manifest=require('./manifest.json'); manifest.version=pkg.version; fs.writeFileSync('manifest.json', JSON.stringify(manifest, null, 2)); const mp=require('./.claude-plugin/marketplace.json'); mp.plugins[0].version=pkg.version; fs.writeFileSync('.claude-plugin/marketplace.json', JSON.stringify(mp, null, 2));\" && pnpm build:mcpb && pnpm exec prettier --write CHANGELOG.md manifest.json .claude-plugin/marketplace.json"
+          "prepareCmd": "node -e \"const fs=require('fs'); const pkg=require('./package.json'); const manifest=require('./manifest.json'); manifest.version=pkg.version; fs.writeFileSync('manifest.json', JSON.stringify(manifest, null, 2)); const plugin=require('./.claude-plugin/plugin.json'); plugin.version=pkg.version; fs.writeFileSync('.claude-plugin/plugin.json', JSON.stringify(plugin, null, 2));\" && pnpm build:mcpb && pnpm exec prettier --write CHANGELOG.md manifest.json .claude-plugin/plugin.json"
         }
       ],
       [
@@ -79,7 +79,7 @@
           "assets": [
             "package.json",
             "manifest.json",
-            ".claude-plugin/marketplace.json",
+            ".claude-plugin/plugin.json",
             "CHANGELOG.md"
           ],
           "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"


### PR DESCRIPTION
## Summary
- prepareCmd no longer requires the deleted `.claude-plugin/marketplace.json`; syncs `.claude-plugin/plugin.json` version instead
- git.assets list updated accordingly
- Adds `version` field to `.claude-plugin/plugin.json` so prepareCmd has a target

## Why
`.claude-plugin/marketplace.json` was removed in bf5a9fe when the marketplace moved to `foxtrottwist/foxtrottwist-plugins`, but the release config kept referencing it. Every semantic-release run has been failing at the prepare step (`require()` throws on the missing file). This brings shortcuts-mcp in line with the pattern just adopted by switchboard/macos-triggers/ask/harden-plugin (foxtrottwist-plugins#2 and friends).

## Test plan
- [x] Local smoke test: ran the prepareCmd's node block — both `manifest.version` and `plugin.version` resolve to `3.3.1`
- [x] Prettier passes on both modified files
- [x] Pre-commit typecheck passes
- [ ] After merge: next push to main triggers semantic-release; the prepare step completes cleanly and bumps `package.json`, `manifest.json`, and `.claude-plugin/plugin.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)