### PR TITLE
chore(skills): deprecate shortcuts-cli skill (absorbed into switchboard)

### DIFF
--- a/skills/shortcuts-cli/SKILL.md
+++ b/skills/shortcuts-cli/SKILL.md
@@ -1,70 +1,18 @@
 ---
 name: shortcuts-cli
-description: "Run, list, view, and sign macOS Shortcuts. Use when the user wants to trigger a Shortcut, discover available Shortcuts, open one in the editor, or sign .shortcut files for distribution. Triggers on: 'run a shortcut', 'trigger a shortcut', 'shortcuts list', 'what shortcuts do I have', 'automate with a shortcut', 'does a shortcut exist for this', 'call a shortcut from a script', 'sign a shortcut', 'open shortcut in editor'."
+description: "DEPRECATED — macOS Shortcuts capability has been absorbed into the Switchboard plugin. Use the switchboard-usage skill instead (run_shortcut, view_shortcut, shortcuts_usage MCP tools, plus the `switchboard shortcuts` CLI). Do not trigger this skill; if a request mentions running, listing, or viewing macOS Shortcuts, defer to switchboard-usage."
 ---
 
-# Shortcuts
+# Shortcuts (deprecated)
 
-Run and manage macOS Shortcuts. Prefer the MCP tools when available — they use AppleScript and handle Location types, permissions, and execution history automatically. Fall back to the `shortcuts` CLI for discovery and signing.
+This skill has been folded into the Switchboard plugin. The shortcuts-mcp
+plugin is on track for retirement once the absorb is verified end-to-end.
 
-## Execution — prefer MCP tools
+For anything Shortcuts-related — running, listing, viewing, discovering, or
+recording purpose annotations — use the **switchboard-usage** skill. The same
+tool names (`run_shortcut`, `view_shortcut`, `shortcuts_usage`) are now
+exposed by the `switchboard` MCP server, and the CLI fallback is
+`switchboard shortcuts <run|list|view>`.
 
-When the shortcuts-mcp MCP server is connected, use these tools instead of the CLI:
-
-- **`run_shortcut(name, input?, purpose?)`** — executes via AppleScript; handles Location types correctly; always pass `purpose` to build annotations
-- **`view_shortcut(name)`** — opens in Shortcuts.app editor
-- **`shortcuts_usage(action, resources?)`** — load `resources: ["shortcuts"]` to discover available shortcuts with purpose annotations before running
-
-**Worked example — run Get Current Weather via MCP:**
-
-```
-run_shortcut(name: "Get Current Weather", input: "Indianapolis, IN", purpose: "check local weather forecast")
-```
-
-**Discover shortcuts before running:**
-
-```
-shortcuts_usage(action: "read", resources: ["shortcuts"])
-```
-
-## Discovery and signing — use the CLI
-
-The MCP doesn't expose `--show-identifiers` or signing. Use the `shortcuts` CLI for these:
-
-```bash
-# List all shortcuts with stable UUIDs
-shortcuts list --show-identifiers
-
-# List shortcuts in a folder
-shortcuts list --folder-name "Shannon"
-
-# Sign a .shortcut file for distribution
-shortcuts sign --input PATH --output PATH [--mode anyone|people-who-know-me]
-```
-
-## Known shortcuts (with UUIDs)
-
-- Get Current Weather — `D238F651-1CCA-4083-A263-1D493C80CCFD`
-- Speak Aloud — `ECAA6D54-8048-47DD-A1EE-736752463B40`
-- Start Screen Saver — `040660C0-1F6F-4CB7-91D2-64309152FB89`
-
-## CLI fallback — when MCP is unavailable
-
-```bash
-# Pipe text input
-echo "Good morning, Law" | shortcuts run "Speak Aloud" --input-path -
-
-# Fire and forget
-shortcuts run "Start Screen Saver"
-
-# Capture output to file (never /dev/stdout — crashes)
-echo "Hello" | shortcuts run "Speak Aloud" --input-path - --output-path /tmp/out.txt
-```
-
-## Constraints
-
-- Always prefer MCP `run_shortcut` over CLI `shortcuts run` — AppleScript handles Location types; the CLI cannot convert Text to Location
-- Never use `--output-path /dev/stdout` with the CLI — crashes with NSInvalidArgumentException
-- CLI `shortcuts view` opens Shortcuts.app GUI — it prints nothing to stdout
-- Error 1743 from MCP means automation permissions are needed: System Settings → Privacy & Security → Automation
-- After CLI `shortcuts run`, verify: `$?` is 0; if output file written, check `[ -s /tmp/out.txt ]`
+Signing `.shortcut` files (`shortcuts sign`) is still done with Apple's
+system CLI — switchboard doesn't wrap that yet.


### PR DESCRIPTION
## Summary

- Rewrites `skills/shortcuts-cli/SKILL.md` as a deprecation pointer to the `switchboard-usage` skill.
- Shortcuts capability has been absorbed into the Switchboard plugin (PR foxtrottwist/SwitchBoard#10, released as v1.2.0). Same tool names (`run_shortcut`, `view_shortcut`, `shortcuts_usage`) are now exposed by the `switchboard` MCP server, plus a `switchboard shortcuts` CLI fallback.
- Goal: stop this skill competing for triggers while the shortcuts-mcp plugin lingers pre-retirement.

## Test plan

- [x] Pre-commit hooks pass (prettier, secretlint, vitest 171/171, typecheck)
- [ ] After merge: confirm the deprecation skill no longer pulls triggers in a fresh session

🤖 Generated with [Claude Code](https://claude.com/claude-code)